### PR TITLE
add alternative source for some firmwares

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # brcmfmac_sdio-firmware-rpi
+
+Useful alternative source for RPi/Broadcom firmwares:
+
+https://github.com/RPi-Distro/firmware-nonfree/tree/master/brcm


### PR DESCRIPTION
For future reference I wanted to add the location of an upstream source for RPi firmwares.