### PR TITLE
Add license file

### DIFF
--- a/LICENCE.broadcom_bcm43xx
+++ b/LICENCE.broadcom_bcm43xx
@@ -1,0 +1,65 @@
+SOFTWARE LICENSE AGREEMENT
+
+The accompanying software in binary code form (“Software”), is licensed to you,
+or, if you are accepting on behalf of an entity, the entity and its affiliates
+exercising rights hereunder (“Licensee”) subject to the terms of this software
+license agreement (“Agreement”), unless Licensee and Broadcom Corporation
+(“Broadcom”) execute a separate written software license agreement governing
+use of the Software. ANY USE, REPRODUCTION, OR DISTRIBUTION OF THE SOFTWARE
+CONSTITUTES LICENSEE’S ACCEPTANCE OF THIS AGREEMENT.
+
+1.	License. Subject to the terms and conditions of this Agreement,
+Broadcom hereby grants to Licensee a limited, non-exclusive, non-transferable,
+royalty-free license: (i) to use and integrate the Software with any other
+software; and (ii) to reproduce and distribute the Software complete,
+unmodified, and as provided by Broadcom, solely for use with Broadcom
+proprietary integrated circuit product(s) sold by Broadcom with which the
+Software was designed to be used, or their successors.
+
+2.	Restrictions. Licensee shall distribute Software with a copy of this
+Agreement. Licensee shall not remove, efface or obscure any copyright or
+trademark notices from the Software. Reproductions of the Broadcom copyright
+notice shall be included with each copy of the Software, except where such
+Software is embedded in a manner not readily accessible to the end user.
+Licensee shall not: (i) use, license, sell or otherwise distribute the Software
+except as provided in this Agreement; (ii) attempt to modify in any way,
+reverse engineer, decompile or disassemble any portion of the Software; or
+(iii) use the Software or other material in violation of any applicable law or
+regulation, including but not limited to any regulatory agency. This Agreement
+shall automatically terminate upon Licensee’s failure to comply with any of the
+terms of this Agreement. In such event, Licensee will destroy all copies of the
+Software and its component parts.
+
+3.	Ownership. The Software is licensed and not sold.  Title to and
+ownership of the Software, including all intellectual property rights thereto,
+and any portion thereof remain with Broadcom or its licensors. Licensee hereby
+covenants that it will not assert any claim that the Software created by or for
+Broadcom infringe any intellectual property right owned or controlled by
+Licensee.
+
+4.     	Disclaimer. THE SOFTWARE IS OFFERED “AS IS,” AND BROADCOM PROVIDES AND
+GRANTS AND LICENSEE RECEIVES NO SUPPORT AND NO WARRANTIES OF ANY KIND, EXPRESS
+OR IMPLIED, BY STATUTE, COMMUNICATION OR CONDUCT WITH LICENSEE, OR OTHERWISE.
+BROADCOM SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A SPECIFIC PURPOSE, OR NONINFRINGEMENT CONCERNING THE SOFTWARE OR
+ANY UPGRADES TO OR DOCUMENTATION FOR THE SOFTWARE. WITHOUT LIMITATION OF THE
+ABOVE, BROADCOM GRANTS NO WARRANTY THAT THE SOFTWARE IS ERROR-FREE OR WILL
+OPERATE WITHOUT INTERRUPTION, AND GRANTS NO WARRANTY REGARDING ITS USE OR THE
+RESULTS THEREFROM INCLUDING, WITHOUT LIMITATION, ITS CORRECTNESS, ACCURACY, OR
+RELIABILITY. TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT SHALL BROADCOM
+OR ANY OF ITS LICENSORS HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES, HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER FOR BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE) OR
+OTHERWISE, ARISING OUT OF THIS AGREEMENT OR USE, REPRODUCTION, OR DISTRIBUTION
+OF THE SOFTWARE, INCLUDING BUT NOT LIMITED TO LOSS OF DATA AND LOSS OF PROFITS,
+EVEN IF SUCH PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. THESE
+LIMITATIONS SHALL APPLY NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY
+LIMITED REMEDY.
+
+5. 	Export Laws.  LICENSEE UNDERSTANDS AND AGREES THAT THE SOFTWARE IS
+SUBJECT TO UNITED STATES AND OTHER APPLICABLE EXPORT-RELATED LAWS AND
+REGULATIONS AND THAT LICENSEE MAY NOT EXPORT, RE-EXPORT OR TRANSFER THE
+SOFTWARE OR ANY DIRECT PRODUCT OF THE SOFTWARE EXCEPT AS PERMITTED UNDER THOSE
+LAWS. WITHOUT LIMITING THE FOREGOING, EXPORT, RE-EXPORT, OR TRANSFER OF THE
+SOFTWARE TO CUBA, IRAN, NORTH KOREA, SUDAN, AND SYRIA IS PROHIBITED.
+

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 Useful alternative source for RPi/Broadcom firmwares:
 
 https://github.com/RPi-Distro/firmware-nonfree/tree/master/brcm
+
+# License
+
+Licence: Redistributable. See LICENCE.broadcom_bcm43xx for details.


### PR DESCRIPTION
Hi,

Would you please consider adding the license file for this firmware.  I'm trying to use this repo as source for rpi wifi and bt firmware packages in buildroot.  Adding the license file would make things easier for me.

LICENCE.broadcom_bcm43xx originated from:
https://github.com/RPi-Distro/firmware-nonfree/blob/86e88fbf0345da49555d0ec34c80b4fbae7d0cd3/LICENCE.broadcom_bcm43xx

The License description origination from:
https://github.com/RPi-Distro/firmware-nonfree/blob/86e88fbf0345da49555d0ec34c80b4fbae7d0cd3/WHENCE

Thanks

Martin