### PR TITLE
Updated coexistence param for post-176 firmware

### DIFF
--- a/firmware/brcm/brcmfmac43455-sdio.txt
+++ b/firmware/brcm/brcmfmac43455-sdio.txt
@@ -95,3 +95,4 @@ fdsslevel_ch11=6
 btc_mode=1
 btc_params8=0x4e20
 btc_params1=0x7530
+btc_params50=0x972c


### PR DESCRIPTION
Firmware release 177 and later for the BCM43455 requires a new
parameter to tune the BT/WiFi coexistence.

See: https://github.com/RPi-Distro/firmware-nonfree/issues/8#issuecomment-615275535